### PR TITLE
Remove runtime caching configuration in Vite setup

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -12,14 +12,6 @@ export default defineConfig({
       scope: '/',
       workbox: {
         cleanupOutdatedCaches: true,
-        runtimeCaching: [
-          {
-            urlPattern: /^https?.*/,
-            handler: 'NetworkFirst',
-          },
-        ],
-        skipWaiting: true,
-        clientsClaim: true,
       },
       manifest: {
         orientation: 'any',


### PR DESCRIPTION
Eliminate the runtime caching configuration from the Vite setup to streamline the build process.